### PR TITLE
fix: allow to use with react 17.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "whatwg-fetch": "^3.6.2"
   },
   "peerDependencies": {
-    "react": "^16.8.6",
+    "react": "^16.8.6 || ^17.0.0",
     "relay-runtime": ">=4.0.0",
     "socket.io-client": ">=2.0.4"
   },


### PR DESCRIPTION
Currently this library emits warnings during npm install if used with React 17. This change extends react peerDependency version range to allow usage with newer react versions